### PR TITLE
Accept any content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const createServer = (options) => {
   const path = options.path || process.cwd()
   const app = express()
 
-  app.use(express.json())
+  app.use(express.json({ type: '*/*' }))
 
   app.post('/1/indexes/:indexName/query', async (req, res) => {
     const { body, params: { indexName } } = req


### PR DESCRIPTION
It's needed since JS client uses `application/x-www-form-urlencoded`.  https://github.com/algolia/algoliasearch-client-javascript/issues/667